### PR TITLE
Lookup Netlify site by id instead of iterating over all the users sites

### DIFF
--- a/lib/deployers/netlify/index.coffee
+++ b/lib/deployers/netlify/index.coffee
@@ -3,6 +3,9 @@ W       = require 'when'
 node    = require 'when/node'
 _       = require 'lodash'
 
+# This is used to resolve a name to a netlify preview domain for site lookups
+preview_domain = ".netlify.com"
+
 module.exports = (root, config) ->
   d = W.defer()
 
@@ -32,8 +35,11 @@ module.exports.config =
 ###
 
 lookup = ->
-  node.call(@client.sites.bind(@client))
-    .then (sites) => _.find(sites, name: @config.name)
+  id = if @config.name.indexOf(preview_domain) != -1
+    @config.name
+  else
+    @config.name + preview_domain
+  node.call(@client.site.bind(@client), id)
 
 ###*
  * Creates a new site on netlify with a given name.


### PR DESCRIPTION
This improves the Netlify deployer.

Right now the deployer fetches all the users sites and iterates over them to find the one matching the name in the config.

This commit changes that to lookup the site by `name + ".netlify.com"`.

This fixes the deployer for users trying to deploy to an existing site they have access to but that they don't own.