### PR TITLE
Neocities deployer

### DIFF
--- a/lib/deployers/neocities/index.coffee
+++ b/lib/deployers/neocities/index.coffee
@@ -1,0 +1,81 @@
+NeoCities = require 'neocities'
+W         = require 'when'
+callbacks = require 'when/callbacks'
+nodefn    = require 'when/node/function'
+readdirp  = require 'readdirp'
+path      = require 'path'
+
+# https://neocities.org/site_files/allowed_types
+allowed_types = [
+  # HTML
+  '.html', '.htm'
+  # Image
+  '.jpg', '.png', '.gif', '.svg', '.ico'
+  # Markdown
+  '.md', '.markdown'
+  # JavaScript
+  '.js', '.json', '.geojson'
+  # CSS
+  '.css'
+  # Text
+  '.txt', '.text', '.csv', '.tsv'
+  # XML
+  '.xml'
+  # Web Fonts
+  '.eot', '.ttf', '.woff', '.woff2', '.svg'
+  # MIDI Files
+  '.mid', '.midi'
+]
+
+module.exports = (root, config) ->
+  d = W.defer()
+
+  client = new NeoCities(config.username, config.password)
+
+  W().with(root: root, client: client, config: config, d: d)
+    .then(lookup)
+    .then(deploy)
+    .done (site) ->
+      d.resolve
+        deployer: 'neocities'
+        url: "http://#{config.username}.neocities.org"
+    , d.reject
+
+  return d.promise
+
+module.exports.config =
+  required: ['username', 'password']
+
+###*
+ * Checks to see if your site is already on neocities or not. Returns either a
+ * site object or undefined.
+ * @return {Promise} promise for either undefined or a site object
+###
+
+lookup = ->
+  callbacks.call(@client.info.bind(@client))
+    .then (res) -> verify(res)
+
+###*
+ * Creates a new deploy for a given site with the contents of the root.
+ * @return {Promise} a promise for a finished deployment
+###
+
+deploy = ->
+  @d.notify("Deploying '#{@config.username}'")
+  nodefn.call(readdirp, { root: @root })
+    .then (res) =>
+      files = res.files
+        .filter (f) -> allowed_types.indexOf(path.extname(f.name)) >= 0
+        .map (f) => name: f.path, path: path.join(@root, f.path)
+      callbacks.call(@client.upload.bind(@client), files)
+        .then (res) -> verify(res)
+
+###*
+ * Verify that the neocities API did not encounter an error.
+ * @param  {Object} result - a result object from neocities
+ * @return {Object} the result object, if no error was found
+###
+
+verify = (result) ->
+  if result.result == 'error' then throw new Error(result.message) else result

--- a/lib/deployers/neocities/readme.md
+++ b/lib/deployers/neocities/readme.md
@@ -1,0 +1,9 @@
+Neocities
+---------
+
+[Neocities](https://neocities.org/) is a community of sites that are bringing back the lost individual creativity of the web. This deployer pushes to Neocities directly through their API. Only [allowed file types](https://neocities.org/site_files/allowed_types) will be pushed, others will be ignored.
+
+### Config Values
+
+- **username**: your neocities account username
+- **password**: your neocities account password

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lodash": "2.x",
     "mime": "1.x",
     "minimatch": "1.x",
+    "neocities": "0.0.3",
     "netlify": "0.2.x",
     "open": "0.0.5",
     "optimist": "0.6.x",

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ Ship is small library that deploys files smoothly to the platforms listed below:
 - [Github Pages](lib/deployers/gh-pages)
 - [Bitballoon](lib/deployers/bitballoon)
 - [Netlify](lib/deployers/netlify)
+- [Neocities](lib/deployers/neocities)
 
 And many more coming soon, like:
 - Linux VPS

--- a/test/fixtures/deployers/neocities/index.html
+++ b/test/fixtures/deployers/neocities/index.html
@@ -1,0 +1,1 @@
+<p>neocities deployer working, yay!</p>

--- a/test/fixtures/deployers/neocities/ship.conf.sample
+++ b/test/fixtures/deployers/neocities/ship.conf.sample
@@ -1,0 +1,3 @@
+neocities:
+  username: 'xxx'
+  password: 'xxx'

--- a/test/neocities.coffee
+++ b/test/neocities.coffee
@@ -1,0 +1,22 @@
+path    = require 'path'
+node    = require 'when/node'
+request = require 'request'
+config  = require '../config'
+
+describe 'neocities', ->
+
+  it 'deploys a site to neocities', ->
+    project = new Ship(root: path.join(_path, 'deployers/neocities'), deployer: 'neocities')
+
+    if process.env.TRAVIS
+      project.configure
+        username: 'ship-testing'
+        password: config.neocities.password
+
+    project.deploy()
+      .tap (res) ->
+        node.call(request, res.url)
+        .tap (r) -> r[0].body.should.match /neocities deployer working, yay!/
+      .then -> project.deploy()
+      .catch (err) -> console.error(err); throw err
+      .should.be.fulfilled


### PR DESCRIPTION
Hey everybody,

I added a deployer for [Neocities](http://neocities.org) based on their [API library](https://github.com/neocities/neocities-node). The API seems to be a bit immature, so there were some things that other deployers do that I wasn't able to recreate:
* There's no API to create a brand new site, you have to sign up for an account first.
* Neocities does not allow deletes of the `index.html` file, so I couldn't do much with a destroy function like the other tests use to clean up. There is also no API call to list files, which also makes "destroying" a site tough.

Neocities also only allows certain file types, so some extra functionality was added to the deployer to filter down to just allowed files.

It looks like at this point, as per [test/readme.md](https://github.com/carrot/ship/blob/master/test/readme.md), I need someone from the core team to add the test account password to the encrypted config file. I've made the `ship-testing` account, let me know who needs the information and I can hand off the account so you can add it to the config file, encrypt, and get the tests to pass.

Let me know how it looks, thanks!