### PR TITLE
Fix 404 in netlify deployer for new sites

### DIFF
--- a/lib/deployers/netlify/index.coffee
+++ b/lib/deployers/netlify/index.coffee
@@ -39,7 +39,7 @@ lookup = ->
     @config.name
   else
     @config.name + preview_domain
-  node.call(@client.site.bind(@client), id)
+  node.call(@client.site.bind(@client), id).catch(() -> null)
 
 ###*
  * Creates a new site on netlify with a given name.


### PR DESCRIPTION
The lookup function would reject the promise if the site didn't already exist, and people would get a 404 error when trying to deploy to a new netlify site.

This change makes sure lookup returns null instead of rejecting the promise and makes `ship path/ -to netlify` work for new sites...